### PR TITLE
Make infer_condition_value recognize the whole truth table

### DIFF
--- a/test-data/unit/check-unreachable-code.test
+++ b/test-data/unit/check-unreachable-code.test
@@ -500,6 +500,46 @@ reveal_type(h)  # N: Revealed type is "builtins.bool"
 [builtins fixtures/ops.pyi]
 [out]
 
+[case testConditionalValuesBinaryOps]
+# flags: --platform linux
+import sys
+
+t_and_t = (sys.platform == 'linux' and sys.platform == 'linux') and 's'
+t_or_t = (sys.platform == 'linux' or sys.platform == 'linux') and 's'
+t_and_f = (sys.platform == 'linux' and sys.platform == 'windows') and 's'
+t_or_f = (sys.platform == 'linux' or sys.platform == 'windows') and 's'
+f_and_t = (sys.platform == 'windows' and sys.platform == 'linux') and 's'
+f_or_t = (sys.platform == 'windows' or sys.platform == 'linux') and 's'
+f_and_f = (sys.platform == 'windows' and sys.platform == 'windows') and 's'
+f_or_f = (sys.platform == 'windows' or sys.platform == 'windows') and 's'
+reveal_type(t_and_t) # N: Revealed type is "Literal['s']"
+reveal_type(t_or_t) # N: Revealed type is "Literal['s']"
+reveal_type(f_and_t) # N: Revealed type is "builtins.bool"
+reveal_type(f_or_t) # N: Revealed type is "Literal['s']"
+reveal_type(t_and_f) # N: Revealed type is "builtins.bool"
+reveal_type(t_or_f) # N: Revealed type is "Literal['s']"
+reveal_type(f_and_f) # N: Revealed type is "builtins.bool"
+reveal_type(f_or_f) # N: Revealed type is "builtins.bool"
+[builtins fixtures/ops.pyi]
+
+[case testConditionalValuesNegation]
+# flags: --platform linux
+import sys
+
+not_t = not sys.platform == 'linux' and 's'
+not_f = not sys.platform == 'windows' and 's'
+not_and_t = not (sys.platform == 'linux' and sys.platform == 'linux') and 's'
+not_and_f = not (sys.platform == 'linux' and sys.platform == 'windows') and 's'
+not_or_t = not (sys.platform == 'linux' or sys.platform == 'linux') and 's'
+not_or_f = not (sys.platform == 'windows' or sys.platform == 'windows') and 's'
+reveal_type(not_t) # N: Revealed type is "builtins.bool"
+reveal_type(not_f) # N: Revealed type is "Literal['s']"
+reveal_type(not_and_t) # N: Revealed type is "builtins.bool"
+reveal_type(not_and_f) # N: Revealed type is "Literal['s']"
+reveal_type(not_or_t) # N: Revealed type is "builtins.bool"
+reveal_type(not_or_f) # N: Revealed type is "Literal['s']"
+[builtins fixtures/ops.pyi]
+
 [case testShortCircuitAndWithConditionalAssignment]
 # flags: --platform linux
 import sys

--- a/test-data/unit/check-unreachable-code.test
+++ b/test-data/unit/check-unreachable-code.test
@@ -550,6 +550,32 @@ reveal_type(unary_minus) # N: Revealed type is "Union[Literal[0], builtins.str]"
 reveal_type(binary_minus) # N: Revealed type is "Union[Literal[0], builtins.str]"
 [builtins fixtures/ops.pyi]
 
+[case testMypyFalseValuesInBinaryOps_no_empty]
+# flags: --platform linux
+import sys
+from typing import TYPE_CHECKING
+
+MYPY = 0
+
+if TYPE_CHECKING and sys.platform == 'linux':
+    def foo1() -> int: ...
+if sys.platform == 'linux' and TYPE_CHECKING:
+    def foo2() -> int: ...
+if MYPY and sys.platform == 'linux':
+    def foo3() -> int: ...
+if sys.platform == 'linux' and MYPY:
+    def foo4() -> int: ...
+
+if TYPE_CHECKING or sys.platform == 'linux':
+    def bar1() -> int: ...  # E: Missing return statement
+if sys.platform == 'linux' or TYPE_CHECKING:
+    def bar2() -> int: ...  # E: Missing return statement
+if MYPY or sys.platform == 'linux':
+    def bar3() -> int: ...  # E: Missing return statement
+if sys.platform == 'linux' or MYPY:
+    def bar4() -> int: ...  # E: Missing return statement
+[builtins fixtures/ops.pyi]
+
 [case testShortCircuitAndWithConditionalAssignment]
 # flags: --platform linux
 import sys

--- a/test-data/unit/check-unreachable-code.test
+++ b/test-data/unit/check-unreachable-code.test
@@ -540,6 +540,16 @@ reveal_type(not_or_t) # N: Revealed type is "builtins.bool"
 reveal_type(not_or_f) # N: Revealed type is "Literal['s']"
 [builtins fixtures/ops.pyi]
 
+[case testConditionalValuesUnsupportedOps]
+# flags: --platform linux
+import sys
+
+unary_minus = -(sys.platform == 'linux') and 's'
+binary_minus = ((sys.platform == 'linux') - (sys.platform == 'linux')) and 's'
+reveal_type(unary_minus) # N: Revealed type is "Union[Literal[0], builtins.str]"
+reveal_type(binary_minus) # N: Revealed type is "Union[Literal[0], builtins.str]"
+[builtins fixtures/ops.pyi]
+
 [case testShortCircuitAndWithConditionalAssignment]
 # flags: --platform linux
 import sys


### PR DESCRIPTION
Fixes #18901. 

Side question: why don't we support boolean literals there (as in `if True or sys.platform == "linux"`)? Is it an escape hatch to make mypy check some {platform,version}-dependent code on all {platform,version}s?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of logical negation and binary logical expressions in condition evaluation, resulting in more accurate detection of unreachable code.

- **Tests**
	- Added test cases for conditional expressions involving platform checks, logical operators, and negations to verify correct unreachable code detection and type inference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->