### PR TITLE
Fix: Handle Trailing Commas and Empty Strings in File Paths

### DIFF
--- a/mypy/config_parser.py
+++ b/mypy/config_parser.py
@@ -332,10 +332,11 @@ def parse_config_file(
 
             # Raise an error if there are any remaining empty strings
             if "" in files_split:
-                raise ValueError("Invalid config: Empty filenames are not allowed except for trailing commas.")
+                raise ValueError(
+                    "Invalid config: Empty filenames are not allowed except for trailing commas."
+                )
 
             options.files = files_split
-
 
         prefix = f"{file_read}: [mypy]: "
         updates, report_dirs = parse_section(

--- a/mypy/test/testconfigparser.py
+++ b/mypy/test/testconfigparser.py
@@ -5,7 +5,7 @@ from mypy.options import Options
 from mypy.config_parser import parse_config_file
 
 class TestConfigParser(TestCase):
-    def test_parse_config_file_with_single_file(self):
+    def test_parse_config_file_with_single_file(self) -> None:
         """A single file should be correctly parsed."""
         with tempfile.TemporaryDirectory() as tmpdirname:
             config_path = os.path.join(tmpdirname, "test_config.ini")
@@ -30,7 +30,7 @@ class TestConfigParser(TestCase):
 
             self.assertEqual(options.files, ["file1.py"])
 
-    def test_parse_config_file_with_no_spaces(self):
+    def test_parse_config_file_with_no_spaces(self) -> None:
         """Files listed without spaces should be correctly parsed."""
         with tempfile.TemporaryDirectory() as tmpdirname:
             config_path = os.path.join(tmpdirname, "test_config.ini")
@@ -55,7 +55,7 @@ class TestConfigParser(TestCase):
 
             self.assertEqual(options.files, ["file1.py", "file2.py", "file3.py"])
 
-    def test_parse_config_file_with_extra_spaces(self):
+    def test_parse_config_file_with_extra_spaces(self) -> None:
         """Files with extra spaces should be correctly parsed."""
         with tempfile.TemporaryDirectory() as tmpdirname:
             config_path = os.path.join(tmpdirname, "test_config.ini")
@@ -80,7 +80,7 @@ class TestConfigParser(TestCase):
 
             self.assertEqual(options.files, ["file1.py", "file2.py", "file3.py"])
 
-    def test_parse_config_file_with_empty_files_key(self):
+    def test_parse_config_file_with_empty_files_key(self) -> None:
         """An empty files key should result in an empty list."""
         with tempfile.TemporaryDirectory() as tmpdirname:
             config_path = os.path.join(tmpdirname, "test_config.ini")
@@ -105,7 +105,7 @@ class TestConfigParser(TestCase):
 
             self.assertEqual(options.files, [])
 
-    def test_parse_config_file_with_only_comma(self):
+    def test_parse_config_file_with_only_comma(self) -> None:
         """A files key with only a comma should raise an error."""
         with tempfile.TemporaryDirectory() as tmpdirname:
             config_path = os.path.join(tmpdirname, "test_config.ini")
@@ -131,7 +131,7 @@ class TestConfigParser(TestCase):
 
             self.assertIn("Invalid config", str(cm.exception))
 
-    def test_parse_config_file_with_only_whitespace(self):
+    def test_parse_config_file_with_only_whitespace(self) -> None:
         """A files key with only whitespace should result in an empty list."""
         with tempfile.TemporaryDirectory() as tmpdirname:
             config_path = os.path.join(tmpdirname, "test_config.ini")
@@ -156,7 +156,7 @@ class TestConfigParser(TestCase):
 
             self.assertEqual(options.files, [])
 
-    def test_parse_config_file_with_mixed_valid_and_invalid_entries(self):
+    def test_parse_config_file_with_mixed_valid_and_invalid_entries(self) -> None:
         """Mix of valid and invalid filenames should raise an error."""
         with tempfile.TemporaryDirectory() as tmpdirname:
             config_path = os.path.join(tmpdirname, "test_config.ini")
@@ -182,7 +182,7 @@ class TestConfigParser(TestCase):
 
             self.assertIn("Invalid config", str(cm.exception))
 
-    def test_parse_config_file_with_newlines_between_files(self):
+    def test_parse_config_file_with_newlines_between_files(self) -> None:
         """Newlines between file entries should be correctly handled."""
         with tempfile.TemporaryDirectory() as tmpdirname:
             config_path = os.path.join(tmpdirname, "test_config.ini")

--- a/mypy/test/testconfigparser.py
+++ b/mypy/test/testconfigparser.py
@@ -1,8 +1,10 @@
 import os
 import tempfile
 from unittest import TestCase, main
-from mypy.options import Options
+
 from mypy.config_parser import parse_config_file
+from mypy.options import Options
+
 
 class TestConfigParser(TestCase):
     def test_parse_config_file_with_single_file(self) -> None:
@@ -20,13 +22,7 @@ class TestConfigParser(TestCase):
 
             options = Options()
 
-            parse_config_file(
-                options,
-                lambda: None,
-                config_path,
-                stdout=None,
-                stderr=None,
-            )
+            parse_config_file(options, lambda: None, config_path, stdout=None, stderr=None)
 
             self.assertEqual(options.files, ["file1.py"])
 
@@ -45,13 +41,7 @@ class TestConfigParser(TestCase):
 
             options = Options()
 
-            parse_config_file(
-                options,
-                lambda: None,
-                config_path,
-                stdout=None,
-                stderr=None,
-            )
+            parse_config_file(options, lambda: None, config_path, stdout=None, stderr=None)
 
             self.assertEqual(options.files, ["file1.py", "file2.py", "file3.py"])
 
@@ -64,19 +54,13 @@ class TestConfigParser(TestCase):
                 f.write(
                     """
                     [mypy]
-                    files =  file1.py ,   file2.py  ,   file3.py   
+                    files =  file1.py ,   file2.py  ,   file3.py
                     """
                 )
 
             options = Options()
 
-            parse_config_file(
-                options,
-                lambda: None,
-                config_path,
-                stdout=None,
-                stderr=None,
-            )
+            parse_config_file(options, lambda: None, config_path, stdout=None, stderr=None)
 
             self.assertEqual(options.files, ["file1.py", "file2.py", "file3.py"])
 
@@ -89,19 +73,13 @@ class TestConfigParser(TestCase):
                 f.write(
                     """
                     [mypy]
-                    files = 
+                    files =
                     """
                 )
 
             options = Options()
 
-            parse_config_file(
-                options,
-                lambda: None,
-                config_path,
-                stdout=None,
-                stderr=None,
-            )
+            parse_config_file(options, lambda: None, config_path, stdout=None, stderr=None)
 
             self.assertEqual(options.files, [])
 
@@ -121,13 +99,7 @@ class TestConfigParser(TestCase):
             options = Options()
 
             with self.assertRaises(ValueError) as cm:
-                parse_config_file(
-                    options,
-                    lambda: None,
-                    config_path,
-                    stdout=None,
-                    stderr=None,
-                )
+                parse_config_file(options, lambda: None, config_path, stdout=None, stderr=None)
 
             self.assertIn("Invalid config", str(cm.exception))
 
@@ -140,19 +112,13 @@ class TestConfigParser(TestCase):
                 f.write(
                     """
                     [mypy]
-                    files =    
+                    files =
                     """
                 )
 
             options = Options()
 
-            parse_config_file(
-                options,
-                lambda: None,
-                config_path,
-                stdout=None,
-                stderr=None,
-            )
+            parse_config_file(options, lambda: None, config_path, stdout=None, stderr=None)
 
             self.assertEqual(options.files, [])
 
@@ -172,13 +138,7 @@ class TestConfigParser(TestCase):
             options = Options()
 
             with self.assertRaises(ValueError) as cm:
-                parse_config_file(
-                    options,
-                    lambda: None,
-                    config_path,
-                    stdout=None,
-                    stderr=None,
-                )
+                parse_config_file(options, lambda: None, config_path, stdout=None, stderr=None)
 
             self.assertIn("Invalid config", str(cm.exception))
 
@@ -199,15 +159,10 @@ class TestConfigParser(TestCase):
 
             options = Options()
 
-            parse_config_file(
-                options,
-                lambda: None,
-                config_path,
-                stdout=None,
-                stderr=None,
-            )
+            parse_config_file(options, lambda: None, config_path, stdout=None, stderr=None)
 
             self.assertEqual(options.files, ["file1.py", "file2.py", "file3.py"])
+
 
 if __name__ == "__main__":
     main()

--- a/mypy/test/testconfigparser.py
+++ b/mypy/test/testconfigparser.py
@@ -1,0 +1,213 @@
+import os
+import tempfile
+from unittest import TestCase, main
+from mypy.options import Options
+from mypy.config_parser import parse_config_file
+
+class TestConfigParser(TestCase):
+    def test_parse_config_file_with_single_file(self):
+        """A single file should be correctly parsed."""
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            config_path = os.path.join(tmpdirname, "test_config.ini")
+
+            with open(config_path, "w") as f:
+                f.write(
+                    """
+                    [mypy]
+                    files = file1.py
+                    """
+                )
+
+            options = Options()
+
+            parse_config_file(
+                options,
+                lambda: None,
+                config_path,
+                stdout=None,
+                stderr=None,
+            )
+
+            self.assertEqual(options.files, ["file1.py"])
+
+    def test_parse_config_file_with_no_spaces(self):
+        """Files listed without spaces should be correctly parsed."""
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            config_path = os.path.join(tmpdirname, "test_config.ini")
+
+            with open(config_path, "w") as f:
+                f.write(
+                    """
+                    [mypy]
+                    files =file1.py,file2.py,file3.py
+                    """
+                )
+
+            options = Options()
+
+            parse_config_file(
+                options,
+                lambda: None,
+                config_path,
+                stdout=None,
+                stderr=None,
+            )
+
+            self.assertEqual(options.files, ["file1.py", "file2.py", "file3.py"])
+
+    def test_parse_config_file_with_extra_spaces(self):
+        """Files with extra spaces should be correctly parsed."""
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            config_path = os.path.join(tmpdirname, "test_config.ini")
+
+            with open(config_path, "w") as f:
+                f.write(
+                    """
+                    [mypy]
+                    files =  file1.py ,   file2.py  ,   file3.py   
+                    """
+                )
+
+            options = Options()
+
+            parse_config_file(
+                options,
+                lambda: None,
+                config_path,
+                stdout=None,
+                stderr=None,
+            )
+
+            self.assertEqual(options.files, ["file1.py", "file2.py", "file3.py"])
+
+    def test_parse_config_file_with_empty_files_key(self):
+        """An empty files key should result in an empty list."""
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            config_path = os.path.join(tmpdirname, "test_config.ini")
+
+            with open(config_path, "w") as f:
+                f.write(
+                    """
+                    [mypy]
+                    files = 
+                    """
+                )
+
+            options = Options()
+
+            parse_config_file(
+                options,
+                lambda: None,
+                config_path,
+                stdout=None,
+                stderr=None,
+            )
+
+            self.assertEqual(options.files, [])
+
+    def test_parse_config_file_with_only_comma(self):
+        """A files key with only a comma should raise an error."""
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            config_path = os.path.join(tmpdirname, "test_config.ini")
+
+            with open(config_path, "w") as f:
+                f.write(
+                    """
+                    [mypy]
+                    files = ,
+                    """
+                )
+
+            options = Options()
+
+            with self.assertRaises(ValueError) as cm:
+                parse_config_file(
+                    options,
+                    lambda: None,
+                    config_path,
+                    stdout=None,
+                    stderr=None,
+                )
+
+            self.assertIn("Invalid config", str(cm.exception))
+
+    def test_parse_config_file_with_only_whitespace(self):
+        """A files key with only whitespace should result in an empty list."""
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            config_path = os.path.join(tmpdirname, "test_config.ini")
+
+            with open(config_path, "w") as f:
+                f.write(
+                    """
+                    [mypy]
+                    files =    
+                    """
+                )
+
+            options = Options()
+
+            parse_config_file(
+                options,
+                lambda: None,
+                config_path,
+                stdout=None,
+                stderr=None,
+            )
+
+            self.assertEqual(options.files, [])
+
+    def test_parse_config_file_with_mixed_valid_and_invalid_entries(self):
+        """Mix of valid and invalid filenames should raise an error."""
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            config_path = os.path.join(tmpdirname, "test_config.ini")
+
+            with open(config_path, "w") as f:
+                f.write(
+                    """
+                    [mypy]
+                    files = file1.py, , , file2.py
+                    """
+                )
+
+            options = Options()
+
+            with self.assertRaises(ValueError) as cm:
+                parse_config_file(
+                    options,
+                    lambda: None,
+                    config_path,
+                    stdout=None,
+                    stderr=None,
+                )
+
+            self.assertIn("Invalid config", str(cm.exception))
+
+    def test_parse_config_file_with_newlines_between_files(self):
+        """Newlines between file entries should be correctly handled."""
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            config_path = os.path.join(tmpdirname, "test_config.ini")
+
+            with open(config_path, "w") as f:
+                f.write(
+                    """
+                    [mypy]
+                    files = file1.py,
+                            file2.py,
+                            file3.py
+                    """
+                )
+
+            options = Options()
+
+            parse_config_file(
+                options,
+                lambda: None,
+                config_path,
+                stdout=None,
+                stderr=None,
+            )
+
+            self.assertEqual(options.files, ["file1.py", "file2.py", "file3.py"])
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Allowed trailing commas in the [mypy] files list.
- Prevented empty entries from being included.
- Unit tests were added to verify both behaviors.
- Ensured consistency between INI and TOML parsing.

NOTE: This replaces PR #18472, as it was closed due to a push issue.

Fixes https://github.com/python/mypy/issues/11171