### PR TITLE
Clone bugfix/gh 18901 reachability

### DIFF
--- a/test-data/unit/check-unreachable-code.test
+++ b/test-data/unit/check-unreachable-code.test
@@ -500,6 +500,46 @@ reveal_type(h)  # N: Revealed type is "builtins.bool"
 [builtins fixtures/ops.pyi]
 [out]
 
+[case testConditionalValuesBinaryOps]
+# flags: --platform linux
+import sys
+
+t_and_t = (sys.platform == 'linux' and sys.platform == 'linux') and 's'
+t_or_t = (sys.platform == 'linux' or sys.platform == 'linux') and 's'
+t_and_f = (sys.platform == 'linux' and sys.platform == 'windows') and 's'
+t_or_f = (sys.platform == 'linux' or sys.platform == 'windows') and 's'
+f_and_t = (sys.platform == 'windows' and sys.platform == 'linux') and 's'
+f_or_t = (sys.platform == 'windows' or sys.platform == 'linux') and 's'
+f_and_f = (sys.platform == 'windows' and sys.platform == 'windows') and 's'
+f_or_f = (sys.platform == 'windows' or sys.platform == 'windows') and 's'
+reveal_type(t_and_t) # N: Revealed type is "Literal['s']"
+reveal_type(t_or_t) # N: Revealed type is "Literal['s']"
+reveal_type(f_and_t) # N: Revealed type is "builtins.bool"
+reveal_type(f_or_t) # N: Revealed type is "Literal['s']"
+reveal_type(t_and_f) # N: Revealed type is "builtins.bool"
+reveal_type(t_or_f) # N: Revealed type is "Literal['s']"
+reveal_type(f_and_f) # N: Revealed type is "builtins.bool"
+reveal_type(f_or_f) # N: Revealed type is "builtins.bool"
+[builtins fixtures/ops.pyi]
+
+[case testConditionalValuesNegation]
+# flags: --platform linux
+import sys
+
+not_t = not sys.platform == 'linux' and 's'
+not_f = not sys.platform == 'windows' and 's'
+not_and_t = not (sys.platform == 'linux' and sys.platform == 'linux') and 's'
+not_and_f = not (sys.platform == 'linux' and sys.platform == 'windows') and 's'
+not_or_t = not (sys.platform == 'linux' or sys.platform == 'linux') and 's'
+not_or_f = not (sys.platform == 'windows' or sys.platform == 'windows') and 's'
+reveal_type(not_t) # N: Revealed type is "builtins.bool"
+reveal_type(not_f) # N: Revealed type is "Literal['s']"
+reveal_type(not_and_t) # N: Revealed type is "builtins.bool"
+reveal_type(not_and_f) # N: Revealed type is "Literal['s']"
+reveal_type(not_or_t) # N: Revealed type is "builtins.bool"
+reveal_type(not_or_f) # N: Revealed type is "Literal['s']"
+[builtins fixtures/ops.pyi]
+
 [case testShortCircuitAndWithConditionalAssignment]
 # flags: --platform linux
 import sys

--- a/test-data/unit/check-unreachable-code.test
+++ b/test-data/unit/check-unreachable-code.test
@@ -550,6 +550,32 @@ reveal_type(unary_minus) # N: Revealed type is "Union[Literal[0], builtins.str]"
 reveal_type(binary_minus) # N: Revealed type is "Union[Literal[0], builtins.str]"
 [builtins fixtures/ops.pyi]
 
+[case testMypyFalseValuesInBinaryOps_no_empty]
+# flags: --platform linux
+import sys
+from typing import TYPE_CHECKING
+
+MYPY = 0
+
+if TYPE_CHECKING and sys.platform == 'linux':
+    def foo1() -> int: ...
+if sys.platform == 'linux' and TYPE_CHECKING:
+    def foo2() -> int: ...
+if MYPY and sys.platform == 'linux':
+    def foo3() -> int: ...
+if sys.platform == 'linux' and MYPY:
+    def foo4() -> int: ...
+
+if TYPE_CHECKING or sys.platform == 'linux':
+    def bar1() -> int: ...  # E: Missing return statement
+if sys.platform == 'linux' or TYPE_CHECKING:
+    def bar2() -> int: ...  # E: Missing return statement
+if MYPY or sys.platform == 'linux':
+    def bar3() -> int: ...  # E: Missing return statement
+if sys.platform == 'linux' or MYPY:
+    def bar4() -> int: ...  # E: Missing return statement
+[builtins fixtures/ops.pyi]
+
 [case testShortCircuitAndWithConditionalAssignment]
 # flags: --platform linux
 import sys

--- a/test-data/unit/check-unreachable-code.test
+++ b/test-data/unit/check-unreachable-code.test
@@ -540,6 +540,16 @@ reveal_type(not_or_t) # N: Revealed type is "builtins.bool"
 reveal_type(not_or_f) # N: Revealed type is "Literal['s']"
 [builtins fixtures/ops.pyi]
 
+[case testConditionalValuesUnsupportedOps]
+# flags: --platform linux
+import sys
+
+unary_minus = -(sys.platform == 'linux') and 's'
+binary_minus = ((sys.platform == 'linux') - (sys.platform == 'linux')) and 's'
+reveal_type(unary_minus) # N: Revealed type is "Union[Literal[0], builtins.str]"
+reveal_type(binary_minus) # N: Revealed type is "Union[Literal[0], builtins.str]"
+[builtins fixtures/ops.pyi]
+
 [case testShortCircuitAndWithConditionalAssignment]
 # flags: --platform linux
 import sys


### PR DESCRIPTION
## **CodeAnt-AI Description**
Determine definite truth/falsity for combined conditions including "and", "or", and "not"

### What Changed
- Conditions with unary "not" are now evaluated for definite true/false outcomes instead of being ignored
- Boolean "and"/"or" expressions are evaluated by combining both sides so cases like platform checks yield definite ALWAYS/MYPY truth values when possible
- Removed prior short-circuit assumptions so both operands contribute to the final truth decision; this fixes incorrect unknown results for some combined conditions
- Added unit tests that cover binary ops, negation, unsupported operators, and TYPE_CHECKING/MYPY interactions to validate reachable/unreachable behavior

### Impact
`✅ Fewer incorrect unreachable-code reports for combined platform/TYPE_CHECKING checks`
`✅ Clearer revealed types for expressions using and/or/not with platform predicates`
`✅ Fewer missed conditional definitions guarded by TYPE_CHECKING or MYPY`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conditional type narrowing for complex expressions involving negation and logical operators (and/or).
  * Enhanced unreachable code detection with more accurate truth-value inference for compound conditions.
  * Refined handling of binary logical operations for better type inference accuracy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->